### PR TITLE
Modified requirements for correct installation on clean virtualenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
-Django>=1.5,<1.6
-sorl-thumbnail
-south
-django-menus
-django-digg-paginator
-bootstrap-admin
-django-concurrency
-sleekxmpp
--e git+https://github.com/liberation/django-massadmin.git@3698237b15d55df1a73d6e5ad7868dbca0f88654#egg=massadmin-master
+Django==1.5.5
+Pillow==2.3.0
+South==0.8.4
+argparse==1.2.1
+bootstrap-admin==0.3.0
+django-concurrency==0.7.1
+django-digg-paginator==0.0.1
+django-mass-edit==1.5.1
+django-menus==1.1.2
+pytils==0.3
+sleekxmpp==1.2.4
+sorl-thumbnail==11.12
+wsgiref==0.1.2


### PR DESCRIPTION
Добавил в requirements недостающие пакеты для установки на чистый virtualenv.

На самом деле еще есть ошибка. pip сперва скачивает все пакеты, затем устанавливает. во время скачивания django-mass-edit происходит ошибка - не может импортировать один из модулей джанго. Если поставить django руками, а затем pip install -r requirements.txt, то все хорошо.
Проблема, видимо, в mass-edit и в таких случаях обычно имеют 2 requirements файла.
Но тем не менее в этом файле все пакеты для запуска python-digest.
