### PR TITLE
title и мета-теги на странице новости

### DIFF
--- a/digest/templates/news_item.html
+++ b/digest/templates/news_item.html
@@ -5,6 +5,21 @@
 {% load likes_inclusion_tags %}
 
 
+{% block page_title %}{{ object.title }} - Еженедельная подборка свежих и самых значимых новостей o Python{% endblock %}
+{% block page_description %}{{ object.title }} - Еженедельная подборка свежих и самых значимых новостей o
+    Python{% endblock %}
+
+{% block extra_head %}
+    <meta name="twitter:site" content="@pydigest"/>
+    <meta name="twitter:title" content="{{ object.title }}"/>
+    <meta name="twitter:description"
+          content="Еженедельная подборка свежих и самых значимых новостей o Python"/>
+    <meta name="twitter:url" content="http://pythondigest.ru{{ object.internal_link }}"/>
+
+    <meta name="description" content='{{ object.description|striptags|truncatechars:500 }}'>
+    <meta name="og:description" content='{{ object.description|striptags|truncatechars:500 }}'>
+{% endblock %}
+
 
 {% block content %}
     <div class="container news-list">


### PR DESCRIPTION
Доброго дня.
Спасибо за полезный проект.
Нередко добавляю ссылки в [pocket](getpocket.com) и в случае вашего сервиса они выглядят крайне прискорбно - невозможно понять что за новость без перехода на нее. Собственно, PR в эту сторону, Pocket и другие аналогичные сервисы, а так же, например, telegram парсят мета-теги, поэтому добавим их на странице новости.

![pocket my list 2016-03-27 22-59-18](https://cloud.githubusercontent.com/assets/627183/14067862/ab1393d0-f46f-11e5-8db1-8cc2f82f5773.jpg)

