### PR TITLE
TESTs. exclude virtualenv directories for report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ branches:
  only:
   - master
 
-script: coverage run manage.py test
+script: coverage run --omit=/**env/** manage.py test
 
 after_success:
   - coverage report


### PR DESCRIPTION
Исключил venv из тестов. Так как основные ошибки и низкое качество кода там.